### PR TITLE
[Feature] Adding AWS as a provider to the models

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,4 +24,5 @@ dependencies:
         - "pinecone-client[grpc]==6.0.0"
         - tavily-python==0.5.3
         - build==1.2.2
+        - langchain-aws==0.2.27
 

--- a/experimental/notebooks/03_tableau_datasource_qa.ipynb
+++ b/experimental/notebooks/03_tableau_datasource_qa.ipynb
@@ -191,6 +191,7 @@
     "    tableau_user=tableau_user,\n",
     "    datasource_luid=datasource_luid,\n",
     "    tooling_llm_model=tooling_model\n",
+    "    model_provider=openai\n",
     ")\n",
     "\n",
     "# add the tool to a List to give to the agent\n",

--- a/experimental/utilities/models.py
+++ b/experimental/utilities/models.py
@@ -3,6 +3,7 @@ import os
 from langchain_openai import ChatOpenAI, AzureChatOpenAI, OpenAIEmbeddings, AzureOpenAIEmbeddings
 from langchain.chat_models.base import BaseChatModel
 from langchain.embeddings.base import Embeddings
+from langchain_aws import ChatBedrockConverse, BedrockEmbeddings
 
 
 def select_model(provider: str = "openai", model_name: str = "gpt-4o-mini", temperature: float = 0.2) -> BaseChatModel:
@@ -15,6 +16,23 @@ def select_model(provider: str = "openai", model_name: str = "gpt-4o-mini", temp
             model_name=model_name,
             temperature=temperature
         )
+    elif provider == "aws":
+        auth_type = 'profile' if os.environ.get("aws_cred_profile",None) is None else 'creds'
+        if auth_type == 'profile':
+            return ChatBedrockConverse(
+                model=model_name,
+                temperature=temperature,
+                credentials_profile_name = os.environ.get("aws_cred_profile")
+            )
+        else:
+            return ChatBedrockConverse(
+                model=model_name,
+                temperature=temperature,
+                aws_access_key_id=os.environ.get("aws_access_key_id"),
+                aws_secret_access_key=os.environ.get("aws_secret_access_key"),
+                aws_session_token=os.environ.get("aws_session_token")
+            )
+
     else:  # default to OpenAI
         return ChatOpenAI(
             model_name=model_name,
@@ -32,6 +50,21 @@ def select_embeddings(provider: str = "openai", model_name: str = "text-embeddin
             openai_api_key=os.environ.get("AZURE_OPENAI_API_KEY"),
             model=model_name
         )
+    elif provider == "aws":
+        auth_type = 'profile' if os.environ.get("aws_cred_profile",None) is None else 'creds'
+        if auth_type == 'profile':
+
+            return BedrockEmbeddings(
+                model=model_name,
+                credentials_profile_name = os.environ.get("aws_cred_profile")
+            )
+        else:
+            return BedrockEmbeddings(
+                model=model_name,
+                aws_access_key_id=os.environ.get("aws_access_key_id"),
+                aws_secret_access_key=os.environ.get("aws_secret_access_key"),
+                aws_session_token=os.environ.get("aws_session_token")
+            )
     else:  # default to OpenAI
         return OpenAIEmbeddings(
             model=model_name,

--- a/pkg/langchain_tableau/utilities/models.py
+++ b/pkg/langchain_tableau/utilities/models.py
@@ -3,6 +3,7 @@ import os
 from langchain_openai import ChatOpenAI, AzureChatOpenAI, OpenAIEmbeddings, AzureOpenAIEmbeddings
 from langchain.chat_models.base import BaseChatModel
 from langchain.embeddings.base import Embeddings
+from langchain_aws import ChatBedrockConverse, BedrockEmbeddings
 
 
 def select_model(provider: str = "openai", model_name: str = "gpt-4o-mini", temperature: float = 0.2) -> BaseChatModel:
@@ -15,6 +16,23 @@ def select_model(provider: str = "openai", model_name: str = "gpt-4o-mini", temp
             model_name=model_name,
             temperature=temperature
         )
+    elif provider == "aws":
+        auth_type = 'profile' if os.environ.get("aws_cred_profile",None) is None else 'creds'
+        if auth_type == 'profile':
+            return ChatBedrockConverse(
+                model=model_name,
+                temperature=temperature,
+                credentials_profile_name = os.environ.get("aws_cred_profile")
+            )
+        else:
+            return ChatBedrockConverse(
+                model=model_name,
+                temperature=temperature,
+                aws_access_key_id=os.environ.get("aws_access_key_id"),
+                aws_secret_access_key=os.environ.get("aws_secret_access_key"),
+                aws_session_token=os.environ.get("aws_session_token")
+            )
+
     else:  # default to OpenAI
         return ChatOpenAI(
             model_name=model_name,
@@ -32,6 +50,21 @@ def select_embeddings(provider: str = "openai", model_name: str = "text-embeddin
             openai_api_key=os.environ.get("AZURE_OPENAI_API_KEY"),
             model=model_name
         )
+    elif provider == "aws":
+        auth_type = 'profile' if os.environ.get("aws_cred_profile",None) is None else 'creds'
+        if auth_type == 'profile':
+
+            return BedrockEmbeddings(
+                model=model_name,
+                credentials_profile_name = os.environ.get("aws_cred_profile")
+            )
+        else:
+            return BedrockEmbeddings(
+                model=model_name,
+                aws_access_key_id=os.environ.get("aws_access_key_id"),
+                aws_secret_access_key=os.environ.get("aws_secret_access_key"),
+                aws_session_token=os.environ.get("aws_session_token")
+            )
     else:  # default to OpenAI
         return OpenAIEmbeddings(
             model=model_name,


### PR DESCRIPTION
### Overview

PR Title: AWS support
Author: Abhi G
Date of Review: August 9th 2025

### Summary
Current `models.py` file contains only OpenAI and Azure authentication. This pull request adds AWS auth allows users to select from wide range of models available on Bedrock.

Functionality & Implementation:
* Added `langchain-aws` to the requirements
* Added `OpenAI` as the default provider in the experimental folder to make sure current tests do not fail
* Updated `models.py` to use `ChatBedrockConverse` and `BedrockEmbeddings` if `AWS` is passed as the model provider
* Added ability to pass an existing `AWS Profile` from an AWS credential file, or `Access Key, Secret & Tokens`
* Made the above mentioned changes to both the experimental and pkg folders
